### PR TITLE
Refactor one-shot shortcut dispatch in CLI

### DIFF
--- a/src/calc/cli.py
+++ b/src/calc/cli.py
@@ -559,6 +559,30 @@ def _handle_repl_command(expr: str, color_mode: str = "auto") -> bool:
     )
 
 
+ONE_SHOT_SHORTCUT_COMMANDS = {
+    "?",
+    "??",
+    "???",
+    ":examples",
+    ":ode",
+    ":linalg",
+    ":la",
+    ":tutorial",
+    ":t",
+    ":tour",
+    ":v",
+    ":version",
+    ":update",
+    ":check",
+}
+
+
+def _handle_one_shot_shortcut_command(expr: str, color_mode: str = "auto") -> bool:
+    if expr not in ONE_SHOT_SHORTCUT_COMMANDS:
+        return False
+    return _handle_repl_command(expr, color_mode=color_mode)
+
+
 def _print_tutorial_step(index: int) -> None:
     print(TUTORIAL_STEPS[index])
 
@@ -686,32 +710,7 @@ def run(argv: list[str] | None = None) -> int:
 
     if remaining:
         expr = " ".join(remaining)
-        if expr == "?":
-            print(HELP_CHAIN_TEXT)
-            return 0
-        if expr == "??":
-            print(HELP_POWER_TEXT)
-            return 0
-        if expr == "???":
-            print(HELP_DEMO_TEXT)
-            return 0
-        if expr == ":examples":
-            print(EXAMPLES_TEXT)
-            return 0
-        if expr == ":ode":
-            print(ODE_TEXT)
-            return 0
-        if expr in {":linalg", ":la"}:
-            print(LINALG_TEXT)
-            return 0
-        if expr in {":tutorial", ":t", ":tour"}:
-            print(TUTORIAL_TEXT)
-            return 0
-        if expr in {":v", ":version"}:
-            print(f"{CLI_NAME} v{VERSION}")
-            return 0
-        if expr in {":update", ":check"}:
-            _print_update_status()
+        if _handle_one_shot_shortcut_command(expr, color_mode=color_mode):
             return 0
         try:
             _execute_expression(

--- a/tests/test_cli_unit.py
+++ b/tests/test_cli_unit.py
@@ -701,6 +701,31 @@ def test_handle_repl_commands(monkeypatch, capsys):
     assert "unknown command" in err
 
 
+def test_handle_one_shot_shortcut_command_supported(monkeypatch):
+    seen: list[tuple[str, str]] = []
+
+    def fake_handle(expr: str, color_mode: str = "auto") -> bool:
+        seen.append((expr, color_mode))
+        return True
+
+    monkeypatch.setattr(cli, "_handle_repl_command", fake_handle)
+    assert cli._handle_one_shot_shortcut_command(":examples", color_mode="never") is True
+    assert seen == [(":examples", "never")]
+
+
+def test_handle_one_shot_shortcut_command_unsupported(monkeypatch):
+    called = False
+
+    def fake_handle(expr: str, color_mode: str = "auto") -> bool:
+        nonlocal called
+        called = True
+        return True
+
+    monkeypatch.setattr(cli, "_handle_repl_command", fake_handle)
+    assert cli._handle_one_shot_shortcut_command(":h") is False
+    assert called is False
+
+
 def test_tutorial_command_flow(capsys):
     state = {"active": False, "index": 0}
     assert cli._tutorial_command(":next", state) is True


### PR DESCRIPTION
## Summary
- remove duplicated one-shot shortcut command branch logic from `run()`
- add `ONE_SHOT_SHORTCUT_COMMANDS` and `_handle_one_shot_shortcut_command()` to route supported one-shot shortcuts through `_handle_repl_command`
- keep one-shot behavior unchanged for non-shortcut inputs while sharing command-dispatch implementation
- add unit coverage for supported and unsupported one-shot shortcut handling

## Testing
- `uv run --group dev pytest tests/test_cli_unit.py -k "one_shot_shortcut or run_shortcut_commands or handle_repl_commands"`
- `uv run --group dev pytest tests/test_cli.py -k "help_alias_chain_shortcuts or contract_one_shot_and_repl_parity_for_success_and_error or contract_json_mode_one_shot_and_repl_parity"`
- `uv run --group dev pytest -q`
- `uv run --group dev pytest --cov=calc --cov-report=term-missing --cov-fail-under=90`

Closes #14
