### PR TITLE
Add deterministic fallback hint mappings

### DIFF
--- a/src/calc/diagnostics.py
+++ b/src/calc/diagnostics.py
@@ -4,6 +4,25 @@ import re
 
 from .core import normalize_expression, relaxed_function_rewrites, reserved_name_suggestion
 
+FALLBACK_HINT_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (
+        re.compile(r"unterminated string literal|eol while scanning string literal|unterminated string"),
+        "check quote balance: close every ' or \" in the expression",
+    ),
+    (
+        re.compile(r"eof in multi-line statement|unexpected eof while parsing"),
+        "check missing closing ')' or unmatched quote",
+    ),
+    (
+        re.compile(r"unexpected character after line continuation character"),
+        "remove stray backslashes; enter plain math syntax",
+    ),
+    (
+        re.compile(r"tokenerror"),
+        "check expression syntax near the end; try :examples for working patterns",
+    ),
+)
+
 
 def should_print_wolfram_hint(exc: Exception) -> bool:
     text = str(exc).lower()
@@ -164,4 +183,7 @@ def hint_for_error(message: str, expr: str | None = None, session_locals: dict |
         return "integer input is too large to materialize; simplify or use a symbolic form first"
     if "empty expression" in text:
         return "enter a math expression, or use :examples"
+    for pattern, hint in FALLBACK_HINT_PATTERNS:
+        if pattern.search(text):
+            return hint
     return None

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -93,3 +93,18 @@ def test_hint_for_error_additional_branches():
         "use sys.set_int_max_str_digits() to increase the limit",
         expr="(100001)!",
     )
+
+
+def test_hint_for_error_fallback_patterns_and_no_noise():
+    assert diagnostics.hint_for_error(
+        "('unterminated string literal (detected at line 1)', (1, 3))",
+        expr="S('x')",
+    ) == "check quote balance: close every ' or \" in the expression"
+    assert diagnostics.hint_for_error(
+        "EOF in multi-line statement",
+        expr="(2+3",
+    ) == "check missing closing ')' or unmatched quote"
+    assert diagnostics.hint_for_error("unexpected character after line continuation character") == (
+        "remove stray backslashes; enter plain math syntax"
+    )
+    assert diagnostics.hint_for_error("different error") is None


### PR DESCRIPTION
## Summary
- add a deterministic fallback hint registry in diagnostics via explicit message-pattern mappings
- keep hints short, single-line, and actionable for unknown parse/token failures
- preserve no-noise behavior for errors that do not match known fallback patterns
- add diagnostics tests for fallback matches and the no-hint case

## Testing
- `uv run --group dev pytest tests/test_diagnostics.py tests/test_cli_unit.py -k "hint_for_error"`
- `uv run --group dev pytest -q`
- `uv run --group dev pytest --cov=calc --cov-report=term-missing --cov-fail-under=90`

Closes #13
