### PR TITLE
chore: add startup benchmark script

### DIFF
--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Measure warm startup latency for the installed phil binary.
+#
+# Usage:
+#   scripts/bench.sh              # uses 'phil' on PATH
+#   scripts/bench.sh /path/to/phil
+#
+# Outputs p50 and p95 over 12 warm runs for three representative invocations.
+# Run before and after any startup optimization to capture before/after.
+set -euo pipefail
+
+PHIL="${1:-phil}"
+
+if ! command -v "$PHIL" &>/dev/null && [ ! -x "$PHIL" ]; then
+    echo "error: '$PHIL' not found — install with: uv tool install philcalc" >&2
+    exit 1
+fi
+
+python3 - "$PHIL" <<'EOF'
+import subprocess, sys, time
+
+def bench(label, cmd, n=12):
+    subprocess.run(cmd, capture_output=True)  # warm-up
+    results = []
+    for _ in range(n):
+        t0 = time.perf_counter()
+        subprocess.run(cmd, capture_output=True)
+        results.append(time.perf_counter() - t0)
+    results.sort()
+    p50 = results[n // 2] * 1000
+    p95 = results[min(int(n * 0.95), n - 1)] * 1000
+    print(f"  {label:<28}  p50={p50:5.0f}ms  p95={p95:5.0f}ms")
+
+phil = sys.argv[1]
+print(f"[bench] {phil}")
+bench(":version",    [phil, ":version"])
+bench("2+2",         [phil, "2+2"])
+bench("d(x^2, x)",  [phil, "d(x^2, x)"])
+bench("solve(x^2-4, x)", [phil, "solve(x^2-4, x)"])
+EOF


### PR DESCRIPTION
## Summary

- Adds `scripts/bench.sh` to measure warm startup latency (p50/p95 over 12 runs)
- Covers four invocations: `:version`, `2+2`, `d(x^2,x)`, `solve(x^2-4,x)`

## Current baseline (this machine)

```
:version                      p50=  223ms  p95=  246ms
2+2                           p50=  225ms  p95=  231ms
d(x^2, x)                     p50=  292ms  p95=  323ms
solve(x^2-4, x)               p50=  243ms  p95=  285ms
```

## Findings from profiling (see issue #21 comment)

The dominant cost is `sympy.polys` (~118ms of SymPy's ~245ms total), loaded because `solve` needs polynomial algorithms. The `urllib.request` claim in the issue is not meaningful — its import is <0.1ms and the network call is already guarded by `isatty()`.

Realistic floor with current feature set: ~200ms. The <150ms target in #21 is not achievable without removing `solve` from the namespace.

Closes #21 investigation phase.